### PR TITLE
 Remove replies property from datastore

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/BlogMessage.java
+++ b/portfolio/src/main/java/com/google/sps/data/BlogMessage.java
@@ -34,11 +34,7 @@ public final class BlogMessage {
     this.message = message;
     this.nickname = nickname;
     this.email = email;
-    if (messageReplies != null) {
-      this.messageReplies = messageReplies;   
-    } else {
-       this.messageReplies = new ArrayList<BlogMessage>();
-    }
+    this.messageReplies = messageReplies;   
     this.timestamp = timestamp;
     this.parentID = parentID;
   }


### PR DESCRIPTION
Since replies are now stored as BlogMessages, the "replies" property in datastore will always be null, which is what was causing the nullPtr exception.
